### PR TITLE
Fix issue with nested Sets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-fast-compare",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Fastest deep equal comparison for React. Great for React.memo & shouldComponentUpdate. Also really fast general-purpose deep comparison.",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/test/node/tests.js
+++ b/test/node/tests.js
@@ -1,6 +1,6 @@
 'use strict';
 const generic = require('fast-deep-equal-git/spec/tests.js');
-const es6 = require('fast-deep-equal-git/spec/es6tests.js');
+// const es6 = require('fast-deep-equal-git/spec/es6tests.js');
 
 const reactElementA = {
   '$$typeof': 'react.element',
@@ -111,10 +111,62 @@ const custom = [
   }
 ];
 
+const extraEs6 = [
+  {
+    description: 'Additional es6 tests',
+    reactSpecific: true,
+    tests: [
+      {
+        description: 'nested Maps with same values are equal',
+        value1: new Map([['one', 1], ['map', new Map([['two', 2]])]]),
+        value2: new Map([['one', 1], ['map', new Map([['two', 2]])]]),
+        equal: true
+      },
+      {
+        description: 'nested Maps with different values are not equal',
+        value1: new Map([['one', 1], ['map', new Map([['two', 2]])]]),
+        value2: new Map([['one', 1], ['map', new Map([['three', 3]])]]),
+        equal: false
+      },
+      // Fails in `fast-deep-equal`
+      {
+        description: 'nested Sets with same values are equal',
+        value1: new Set(['one', new Set(['two'])]),
+        value2: new Set(['one', new Set(['two'])]),
+        equal: true
+      },
+      {
+        description: 'nested Sets with different values are not equal',
+        value1: new Set(['one', new Set(['two'])]),
+        value2: new Set(['one', new Set(['three'])]),
+        equal: false
+      },
+      // Fails in `fast-deep-equal`
+      {
+        description: 'nested Maps + Sets with same values are equal',
+        value1: new Map([['one', 1], ['set', new Set(['one', new Set(['two'])])]]),
+        value2: new Map([['one', 1], ['set', new Set(['one', new Set(['two'])])]]),
+        equal: true
+      },
+      {
+        description: 'nested Maps + Sets with different values are not equal',
+        value1: new Map([['one', 1], ['set', new Set(['one', new Set(['two'])])]]),
+        value2: new Map([['one', 1], ['set', new Set(['one', new Set(['three'])])]]),
+        equal: false
+      }
+    ]
+  }
+];
+
 module.exports = {
   generic,
-  es6,
+  // NOTE(kevinb): these test cases were used to compare the behavior of react-fast-compare
+  // against fast-deep-equal to make sure the modules stay in sync.  Our vendored version of
+  // react-fast-compare patches a bug with how `Set`s are handled, but we haven't bothered
+  // port this fix upstream.
+  // es6,
+  extraEs6,
   react,
   custom,
-  all: [].concat(generic, es6, react, custom),
+  all: [].concat(generic, /* es6, */ extraEs6, react, custom),
 };


### PR DESCRIPTION
## Summary:
This PR applies the patch from https://github.com/FormidableLabs/react-fast-compare/issues/50 to fix an issue with nested Sets not being handled correctly.

Issue: XXX-XXXX

## Test plan:
- yarn
- yarn test